### PR TITLE
Move trigger guard to slash command first line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ codemob is early-stage. Optimize for the common user, not power users. Consider 
 
 **Interactive picker:** When a command needs the user to select a mob, use the shared `pickMob()` function in `root.go`. Configure it via `pickerOpts` (marker, default value, root hint, output writer) rather than duplicating the table/prompt logic.
 
+**Command registration:** `root.go` has two switch statements over commands that must stay in sync: the guard/upgrade switch (rejects unknown commands and decides upgrade check) and the dispatch switch (routes to handlers). When adding a new command, add it to both.
+
 **Bug fixes need tests:** When fixing a bug - whether reported by the user or discovered independently - always consider adding a regression test in `integration_test.go`. The test suite is comprehensive and easy to extend. A bug that was worth fixing is worth preventing from coming back.
 
 ## Slash commands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,28 +71,20 @@ func Execute() error {
 	cmd := os.Args[1]
 	args := os.Args[2:]
 
-	// Reject unknown commands before any side effects (e.g., upgrade refresh).
+	// Reject unknown commands before any side effects and decide upgrade check.
+	// Keep in sync with the dispatch switch below (see CLAUDE.md).
 	switch cmd {
-	case "new", "list", "ls", "resume", "init", "reinit", "uninstall",
-		"remove", "purge", "path", "open", "info",
-		"switch", "list-others", "check-queue", "queue", "inject-args",
-		"version", "--version", "-v", "help", "--help", "-h":
-		// known command
-	default:
-		return fmt.Errorf("unknown command: %s. Run 'codemob help' for usage.", cmd)
-	}
-
-	// Check for version upgrade on user-facing commands
-	switch cmd {
-	case "switch", "list-others", "check-queue", "queue", "inject-args", "path",
-		"init", "reinit", "uninstall", "version", "--version", "-v", "help", "--help", "-h":
-		// skip upgrade check
-	default:
+	case "new", "list", "ls", "resume", "remove", "purge", "open", "info":
 		repoRoot := ""
 		if root, err := mob.FindRepoRoot(); err == nil {
 			repoRoot = root
 		}
 		mob.CheckUpgrade(Version, repoRoot)
+	case "switch", "list-others", "check-queue", "queue", "inject-args", "path",
+		"init", "reinit", "uninstall", "version", "--version", "-v", "help", "--help", "-h":
+		// internal/setup commands: skip upgrade check
+	default:
+		return fmt.Errorf("unknown command: %s. Run 'codemob help' for usage.", cmd)
 	}
 
 	switch cmd {
@@ -307,7 +299,7 @@ func createMob(root string, cfg *mob.Config, name, agent string) (string, error)
 		return "", err
 	}
 
-	mob.CopySlashCommands(root, worktreePath)
+	mob.CopyClaudeSlashCommands(root, worktreePath)
 
 	cfg.Mobs = append(cfg.Mobs, mob.Mob{
 		Name:      name,

--- a/internal/mob/init.go
+++ b/internal/mob/init.go
@@ -123,9 +123,9 @@ If the command fails, tell the user: "This command can only be used from within 
 	},
 }
 
-// SlashCommands returns Claude Code slash commands (description as first line, then body).
+// ClaudeSlashCommands returns Claude Code slash commands (description as first line, then body).
 // When multipleAgents is false, the change-agent command is omitted.
-func SlashCommands(multipleAgents bool) map[string]string {
+func ClaudeSlashCommands(multipleAgents bool) map[string]string {
 	cmds := make(map[string]string)
 	for name, def := range slashCommandDefs {
 		if name == "change-agent" && !multipleAgents {
@@ -146,7 +146,7 @@ func CodexPrompts(multipleAgents bool) map[string]string {
 		if name == "change-agent" && !multipleAgents {
 			continue
 		}
-		prompt := fmt.Sprintf("---\ndescription: %s\n---\n\n%s\n", def.Description, def.Body)
+		prompt := fmt.Sprintf("---\ndescription: %s%s\n---\n\n%s%s\n", triggerGuard, def.Description, bodyGuard, def.Body)
 		prompts["mob-"+name+".md"] = prompt
 		prompts["codemob-"+name+".md"] = prompt
 	}
@@ -586,7 +586,7 @@ func setupClaudeCommands(repoRoot string, multipleAgents bool) {
 	os.MkdirAll(commandsDir, 0755)
 
 	installed := 0
-	for name, content := range SlashCommands(multipleAgents) {
+	for name, content := range ClaudeSlashCommands(multipleAgents) {
 		dest := filepath.Join(commandsDir, name)
 		// Check if file exists and has same content
 		existing, err := os.ReadFile(dest)
@@ -607,7 +607,7 @@ func setupClaudeCommands(repoRoot string, multipleAgents bool) {
 	}
 }
 
-func CopySlashCommands(srcRoot, destRoot string) {
+func CopyClaudeSlashCommands(srcRoot, destRoot string) {
 	srcDir := filepath.Join(srcRoot, ".claude", "commands")
 	destDir := filepath.Join(destRoot, ".claude", "commands")
 
@@ -827,7 +827,7 @@ func Uninstall(installDir string) error {
 		info("Removed .codemob/ and all worktrees")
 
 		// Remove slash commands from project
-		for name := range SlashCommands(true) {
+		for name := range ClaudeSlashCommands(true) {
 			os.Remove(filepath.Join(repoRoot, ".claude", "commands", name))
 		}
 		info("Removed codemob slash commands from .claude/commands/")

--- a/internal/mob/integration_test.go
+++ b/internal/mob/integration_test.go
@@ -296,7 +296,7 @@ func TestSlashCommandsFirstLineContainsTriggerGuard(t *testing.T) {
 		t.Fatalf("could not read commands dir: %v", err)
 	}
 
-	guard := "Do NOT invoke unless user explicitly mentions"
+	guard := `MUST HAVE "mob"/"codemob" in user message.`
 
 	for _, entry := range entries {
 		if !strings.HasPrefix(entry.Name(), "mob-") {


### PR DESCRIPTION
The trigger guard ("Do NOT invoke unless user explicitly mentions mob or codemob") was only in the body of slash commands, which Claude reads after skill matching already happened. Move it to the first line (the description), which is visible in the skill listing and prevents false-positive matches on generic words like "new", "list", "switch".