### PR TITLE
Fix init failing when mobs_dir is outside repo root

### DIFF
--- a/internal/mob/mob.go
+++ b/internal/mob/mob.go
@@ -146,7 +146,11 @@ func SaveConfig(repoRoot string, cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
-	return os.WriteFile(filepath.Join(repoRoot, ConfigFile), append(data, '\n'), 0644)
+	p := filepath.Join(repoRoot, ConfigFile)
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	return os.WriteFile(p, append(data, '\n'), 0644)
 }
 
 // Reconcile removes mobs from config whose worktree no longer exists on disk.


### PR DESCRIPTION
## Summary
- `SaveConfig` now ensures `.codemob/` exists before writing `config.json`
- Fixes `codemob init` failing when the user picks an external mobs directory (enclosing or global), since `MkdirAll` only created the external path but never the in-repo `.codemob/`

## Test plan
- [x] Run `codemob init` and pick option 2 (enclosing dir) - should succeed
- [ ] Run `codemob init` and pick option 3 (global dir) - should succeed
- [x] Run `codemob init` and pick option 1 (project dir) - should still work as before