### PR TITLE
Fix stale queue path in info command and shell check-queue

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -80,14 +80,24 @@ func cmdInfo() error {
 		}
 	}
 
-	// --- Queue ---
-	section("Queue")
-	queuePath := filepath.Join(root, mob.CodemobDir, "queue.json")
-	queueData, err := os.ReadFile(queuePath)
-	if err != nil {
-		kv("queue.json", "(none)")
+	// --- Queues ---
+	section("Queues")
+	queuesPath := filepath.Join(root, mob.CodemobDir, "queues")
+	queueEntries, err := os.ReadDir(queuesPath)
+	if err != nil || len(queueEntries) == 0 {
+		kv("queued actions", "(none)")
 	} else {
-		fmt.Printf("  %s\n", strings.TrimSpace(string(queueData)))
+		for _, e := range queueEntries {
+			if e.IsDir() {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(queuesPath, e.Name()))
+			if err != nil {
+				continue
+			}
+			name := strings.TrimSuffix(e.Name(), ".json")
+			kv(name, strings.TrimSpace(string(data)))
+		}
 	}
 
 	// --- Session ---

--- a/codemob-shell.sh
+++ b/codemob-shell.sh
@@ -44,7 +44,7 @@ claude() {
       done < <(command codemob inject-args claude 2>/dev/null)
       CODEMOB_MOB="$codemob_mob" command claude "${extra_args[@]}" "$@"
       local ec=$?
-      codemob check-queue 2>/dev/null
+      CODEMOB_MOB="$codemob_mob" codemob check-queue 2>/dev/null
       return $ec
       ;;
   esac
@@ -67,7 +67,7 @@ codex() {
       done < <(command codemob inject-args codex 2>/dev/null)
       CODEMOB_MOB="$codemob_mob" command codex "${extra_args[@]}" "$@"
       local ec=$?
-      codemob check-queue 2>/dev/null
+      CODEMOB_MOB="$codemob_mob" codemob check-queue 2>/dev/null
       return $ec
       ;;
   esac


### PR DESCRIPTION
## Summary
Follow-up to #22 (per-mob queue files). Two things were missed:

- **`codemob info`**: still read from the old `queue.json` path, so it always showed `(none)` even with active queues. Now lists all files in `queues/` directory.
- **shell wrappers**: `check-queue` ran without `CODEMOB_MOB` set, so `CurrentMobName()` returned empty and the shell-path queue processing silently did nothing. Now passes `CODEMOB_MOB` through.

## Test plan
- [x] All 61 existing tests pass
- [ ] Run `codemob info` while a queue action is pending - verify it shows up
- [ ] Shell-launched session (`claude --mob`) processes queue actions on exit