### PR TITLE
Fix agent termination cleanup and Codex slash command UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 **Claude** (primary focus) and **Codex** supported out of the box.
 Other terminal-based agents work too - `codemob cd` drops you into the workspace.
 
+> Codex integration works but has rough edges around in-session slash commands (`/mob-new`, `/mob-switch`, etc.). Workspace creation, switching, and lifecycle management from the terminal all work fine. Improving this is a high priority.
+
 </details>
 
 ## How

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1093,7 +1093,7 @@ func spawnAgent(root, binPath string, args []string, workdir string) error {
 					if _, err := os.Stat(queuePath); err == nil {
 						mobStatus("Stopping agent...")
 						if cmd.Process != nil {
-							cmd.Process.Signal(syscall.SIGTERM)
+							cmd.Process.Signal(syscall.SIGINT)
 						}
 						return
 					}
@@ -1107,6 +1107,12 @@ func spawnAgent(root, binPath string, args []string, workdir string) error {
 	err := cmd.Wait()
 	signal.Stop(sigCh)
 	close(done)
+
+	// Drain kitty keyboard protocol stack in case the agent exited without
+	// popping it (e.g. SIGTERM during queue-based switching). This is a no-op
+	// if the protocol was never pushed.
+	fmt.Fprint(os.Stdout, "\033[<10u")
+
 	return err
 }
 

--- a/internal/mob/init.go
+++ b/internal/mob/init.go
@@ -30,7 +30,7 @@ const triggerGuard = `MUST HAVE "mob"/"codemob" in user message. `
 
 // Layer 2 (bodyGuard): prepended to the skill body (loaded after invocation).
 // If the agent invokes despite layer 1, this instruction tells it to abort.
-const bodyGuard = `STOP. Re-read the user's message. If it does not literally contain the word "mob" or "codemob", do NOT proceed. Instead, apologize for the false match and ask what they meant.
+const bodyGuard = `STOP. Re-read the user's message that TRIGGERED this command. If that original message does not literally contain the word "mob" or "codemob", do NOT proceed. Instead, apologize for the false match and ask what they meant. This check applies ONLY to the triggering message - follow-up replies (like "y", "yes", a name, etc.) do not need to contain "mob"/"codemob".
 
 `
 


### PR DESCRIPTION
## Summary

- Use SIGINT instead of SIGTERM when stopping agents via queue actions, so agents (especially Claude Code) run their full cleanup path - hooks, terminal state restore, session save
- Drain kitty keyboard protocol stack after agent exit to prevent terminal corruption where Ctrl+C shows as raw `^[[99;5u` escape sequences
- Scope slash command body guard to the triggering message only, fixing Codex rejecting follow-up confirmations like "y" or "yes" because they don't contain "mob"/"codemob"
- Note Codex slash command rough edges in README

## Test plan

- [x] Verified kitty protocol fix - terminal stays clean after queue-based switch
- [x] Verified SIGINT - Claude exits gracefully on queue action
- [x] Verified Codex - slash commands accept follow-up confirmations
- [ ] Verify on a terminal without kitty KB protocol support (escape sequence should be silently ignored)