### PR TITLE
Use --force in /mob-remove for non-current mobs

### DIFF
--- a/internal/mob/init.go
+++ b/internal/mob/init.go
@@ -94,7 +94,14 @@ Once the user confirms which agent they want, run ` + "`codemob queue change-age
 
 Ask the user which mob they want to remove.
 
-If they choose a DIFFERENT mob (not the one marked with ◀), run ` + "`codemob remove <name>`" + ` directly. No session confirmation needed since the current session stays alive.
+If they choose a DIFFERENT mob (not the one marked with ◀):
+
+This is a destructive operation. Before proceeding, warn the user:
+"This will permanently delete mob '<name>'. Any unstaged, uncommitted, or unpushed changes in that workspace will be permanently lost. Are you sure?"
+
+Only proceed after the user confirms. If they decline, cancel the operation.
+
+Once confirmed, run ` + "`codemob remove --force <name>`" + ` using the Bash tool.
 
 If they choose the CURRENT mob (marked with ◀):
 


### PR DESCRIPTION
## Summary
- `/mob-remove` slash command now warns the user about destructive consequences (unstaged/uncommitted/unpushed changes will be lost) when removing a non-current mob
- Uses `codemob remove --force <name>` to bypass the interactive y/N prompt that agents can't handle cleanly
- The `--force` flag already existed in the CLI - the slash command just wasn't using it

Closes #32

## Test plan
- [x] All 72 existing tests pass
- [x] Run `/mob-remove`, pick a non-current mob, verify the agent warns about data loss before proceeding
- [x] Confirm the agent uses `--force` and doesn't get stuck on the interactive prompt