### PR TITLE
Add --cd flag to codemob new

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -401,11 +401,14 @@ func cmdNew(args []string) error {
 	name := ""
 	agent := cfg.DefaultAgent
 	noLaunch := false
+	cdOnly := false
 
 	for i := 0; i < len(args); i++ {
 		switch {
 		case args[i] == "--no-launch":
 			noLaunch = true
+		case args[i] == "--cd":
+			cdOnly = true
 		case args[i] == "--agent":
 			if i+1 >= len(args) {
 				return fmt.Errorf("--agent requires a value (e.g., --agent codex)")
@@ -433,6 +436,10 @@ func cmdNew(args []string) error {
 		return err
 	}
 
+	if cdOnly {
+		fmt.Println(worktreePath)
+		return nil
+	}
 	if !noLaunch {
 		return launchAgent(root, agent, worktreePath, false)
 	}

--- a/codemob-shell.sh
+++ b/codemob-shell.sh
@@ -19,6 +19,21 @@ codemob() {
       fi
       cd "$dir"
       ;;
+    new)
+      local has_cd=false
+      for arg in "$@"; do
+        [ "$arg" = "--cd" ] && has_cd=true
+      done
+      if $has_cd; then
+        local out dir
+        out="$(command codemob "$@")" || return $?
+        dir="$(echo "$out" | tail -1)"
+        echo "$out" | sed '$d'
+        cd "$dir"
+      else
+        command codemob "$@"
+      fi
+      ;;
     *)  command codemob "$@" ;;
   esac
 }

--- a/internal/mob/integration_test.go
+++ b/internal/mob/integration_test.go
@@ -1731,3 +1731,39 @@ func TestSlashCommandsCopiedToExternalWorktree(t *testing.T) {
 		}
 	}
 }
+
+func TestNewCdPrintsWorktreePath(t *testing.T) {
+	bin := buildCore(t)
+	_, repoPath := setupTestRepo(t)
+	initRepo(t, bin, repoPath)
+
+	// when
+	out := runCore(t, bin, repoPath, "new", "cd-test", "--cd")
+
+	// then -> last line of output should be the worktree path
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	lastLine := lines[len(lines)-1]
+	worktreePath := filepath.Join(repoPath, ".codemob", "mobs", "cd-test")
+	if clean, err := filepath.EvalSymlinks(worktreePath); err == nil {
+		worktreePath = clean
+	}
+	if lastLine != worktreePath {
+		t.Errorf("expected last line to be worktree path %q, got %q", worktreePath, lastLine)
+	}
+
+	// then -> worktree should exist on disk
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Errorf("worktree not created: %v", err)
+	}
+
+	// then -> config should have the mob
+	cfg := readConfig(t, repoPath)
+	mobs := cfg["mobs"].([]interface{})
+	if len(mobs) != 1 {
+		t.Fatalf("expected 1 mob, got %d", len(mobs))
+	}
+	mob := mobs[0].(map[string]interface{})
+	if mob["name"] != "cd-test" {
+		t.Errorf("expected mob name=cd-test, got %v", mob["name"])
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--cd` flag to `codemob new` so users can create a mob and land directly in the worktree directory without launching an agent session
- Go binary prints the worktree path as the last stdout line when `--cd` is set
- Shell function intercepts `--cd`, captures the path, and `cd`s into it

Closes #27

## Test plan
- [x] Added `TestNewCdPrintsWorktreePath` integration test
- [ ] Manual: `mob new --cd foo` creates mob and changes directory
- [ ] Manual: `mob new --cd` (no name) auto-generates name and cd's
- [ ] Manual: `mob new foo` (no --cd) still launches agent as before