### PR TITLE
List mob names in `purge` confirmation prompt

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -666,7 +666,8 @@ func cmdPurge(_ []string) error {
 	fmt.Println("  The following mobs will be permanently removed:")
 	fmt.Println()
 	for _, m := range cfg.Mobs {
-		fmt.Printf("    %s✗%s %s\n", r, rst, m.Name)
+		branch := mob.ActualBranch(root, cfg, &m)
+		fmt.Printf("    %s✗%s %s  (%s)\n", r, rst, m.Name, branch)
 	}
 	fmt.Println()
 	fmt.Printf("  Any %suncommitted or unpushed changes%s in those worktrees will be %spermanently lost%s.\n", r, rst, r, rst)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -667,7 +667,7 @@ func cmdPurge(_ []string) error {
 	fmt.Println()
 	for _, m := range cfg.Mobs {
 		branch := mob.ActualBranch(root, cfg, &m)
-		fmt.Printf("    %s✗%s %s  (%s)\n", r, rst, m.Name, branch)
+		fmt.Printf("    %s✗%s %s  (branch: %s)\n", r, rst, m.Name, branch)
 	}
 	fmt.Println()
 	fmt.Printf("  Any %suncommitted or unpushed changes%s in those worktrees will be %spermanently lost%s.\n", r, rst, r, rst)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -665,9 +666,16 @@ func cmdPurge(_ []string) error {
 	fmt.Println()
 	fmt.Println("  The following mobs will be permanently removed:")
 	fmt.Println()
+	var buf bytes.Buffer
+	w := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tBRANCH")
 	for _, m := range cfg.Mobs {
 		branch := mob.ActualBranch(root, cfg, &m)
-		fmt.Printf("    %s✗%s %s  (branch: %s)\n", r, rst, m.Name, branch)
+		fmt.Fprintf(w, "%s\t%s\n", m.Name, branch)
+	}
+	w.Flush()
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		fmt.Printf("    %s\n", line)
 	}
 	fmt.Println()
 	fmt.Printf("  Any %suncommitted or unpushed changes%s in those worktrees will be %spermanently lost%s.\n", r, rst, r, rst)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -663,7 +663,12 @@ func cmdPurge(_ []string) error {
 	fmt.Println()
 	fmt.Printf("  %s⚠ DESTRUCTIVE OPERATION%s\n", r, rst)
 	fmt.Println()
-	fmt.Printf("  This will permanently remove all %s%d mob(s)%s and their worktrees.\n", r, len(cfg.Mobs), rst)
+	fmt.Println("  The following mobs will be permanently removed:")
+	fmt.Println()
+	for _, m := range cfg.Mobs {
+		fmt.Printf("    %s✗%s %s\n", r, rst, m.Name)
+	}
+	fmt.Println()
 	fmt.Printf("  Any %suncommitted or unpushed changes%s in those worktrees will be %spermanently lost%s.\n", r, rst, r, rst)
 	fmt.Println()
 	fmt.Printf("  %sThis cannot be undone.%s\n", r, rst)

--- a/internal/mob/integration_test.go
+++ b/internal/mob/integration_test.go
@@ -766,6 +766,15 @@ func TestPurge(t *testing.T) {
 		t.Fatalf("clear failed: %s\n%s", err, out)
 	}
 
+	// then -> output lists mob names before confirmation
+	outStr := string(out)
+	if !strings.Contains(outStr, "one") {
+		t.Error("purge output should list mob 'one'")
+	}
+	if !strings.Contains(outStr, "two") {
+		t.Error("purge output should list mob 'two'")
+	}
+
 	// then -> no mobs
 	cfg := readConfig(t, repoPath)
 	mobs, _ := cfg["mobs"].([]interface{})

--- a/internal/mob/integration_test.go
+++ b/internal/mob/integration_test.go
@@ -766,13 +766,13 @@ func TestPurge(t *testing.T) {
 		t.Fatalf("clear failed: %s\n%s", err, out)
 	}
 
-	// then -> output lists mob names before confirmation
+	// then -> output lists mob names and branches before confirmation
 	outStr := string(out)
-	if !strings.Contains(outStr, "one") {
-		t.Error("purge output should list mob 'one'")
+	if !strings.Contains(outStr, "one") || !strings.Contains(outStr, "mob/one") {
+		t.Errorf("purge output should list mob 'one' with branch, got: %s", outStr)
 	}
-	if !strings.Contains(outStr, "two") {
-		t.Error("purge output should list mob 'two'")
+	if !strings.Contains(outStr, "two") || !strings.Contains(outStr, "mob/two") {
+		t.Errorf("purge output should list mob 'two' with branch, got: %s", outStr)
 	}
 
 	// then -> no mobs


### PR DESCRIPTION
Closes #35

adds listing of mobs to be deleted in the `purge` operation:
```
❯ codemob purge

  ⚠ DESTRUCTIVE OPERATION

  The following mobs will be permanently removed:

    NAME              BRANCH
    epic-dragonfruit  mob/epic-dragonfruit
    dark-lime         mob/dark-lime
    test-test         mob/test-test
    loud-grape        mob/loud-grape
    rough-radish      mob/rough-radish
    daring-jackfruit  mob/daring-jackfruit
    zippy-banana      mob/zippy-banana
    epic-fig          fix/mob-remove-non-interactive
    shy-fig           purge-list-mobs

  Any uncommitted or unpushed changes in those worktrees will be permanently lost.

  This cannot be undone.

  Are you sure? [y/N]:
```

## Summary
- `codemob purge` now lists each mob by name in the confirmation prompt instead of just showing a count
- Helps the user see exactly what they're about to delete before confirming

## Test plan
- [x] Existing `TestPurge` extended to verify mob names appear in output
- [x] All purge-related tests pass